### PR TITLE
Update runtime to 48>50 and more

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "require-important-update": true
+}

--- a/io.github.Ethanscharlie.albumripper.json
+++ b/io.github.Ethanscharlie.albumripper.json
@@ -1,7 +1,7 @@
 {
     "id" : "io.github.Ethanscharlie.albumripper",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "48",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
     "command" : "albumripper",
     "finish-args" : [
@@ -15,26 +15,58 @@
     ],
     "cleanup" : [
         "/include",
-        "/lib/pkgconfig",
-        "/man",
+        "/share/bash-completion",
         "/share/doc",
-        "/share/gtk-doc",
+        "/share/fish",
         "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
+        "/share/zsh"
+    ],
+    "cleanup-commands": [
+        "python3 -m compileall --invalidation-mode=unchecked-hash /app"
     ],
     "modules" : [
         "python3-requests.json",
         {
+            "name": "quickjs",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make",
+                "make install PREFIX=/app"
+            ],
+            "cleanup": [
+                "/bin/qjsc"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://bellard.org/quickjs/quickjs-2025-09-13-2.tar.xz",
+                    "sha256": "996c6b5018fc955ad4d06426d0e9cb713685a00c825aa5c0418bd53f7df8b0b4",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 138263,
+                        "stable-only": true,
+                        "url-template": "https://bellard.org/quickjs/quickjs-$version.tar.xz"
+                    }
+                }
+            ]
+        },
+        {
             "name" : "albumripper",
             "builddir" : true,
             "buildsystem" : "meson",
-            "sources" : [{
-                "type" : "git",
-                "url" : "https://github.com/Ethanscharlie/albumripper.git",
-                "tag": "v1.2.1"
-            }]
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/Ethanscharlie/albumripper.git",
+                    "tag": "v1.2.1",
+                    "commit": "885ddef565121ec1f7c6e62569f022dc7e3d56e7",
+                    "x-checker-data": {
+                        "is-main-source": true,
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
+                }
+            ]
         }
     ]
 }

--- a/python3-requests.json
+++ b/python3-requests.json
@@ -1,19 +1,45 @@
 {
-    "name": "python3-package-installation",
+    "name": "python3-requests",
     "buildsystem": "simple",
-    "build-commands": [
-        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} --no-build-isolation mutagen yt-dlp"
-    ],
-    "sources": [
+    "build-commands": [],
+    "modules": [
         {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/b0/7a/620f945b96be1f6ee357d211d5bf74ab1b7fe72a9f1525aafbfe3aee6875/mutagen-1.47.0-py3-none-any.whl",
-            "sha256": "edd96f50c5907a9539d8e5bba7245f62c9f520aef333d13392a79a4f70aca719"
+            "name": "python3-mutagen",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"mutagen\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b0/7a/620f945b96be1f6ee357d211d5bf74ab1b7fe72a9f1525aafbfe3aee6875/mutagen-1.47.0-py3-none-any.whl",
+                    "sha256": "edd96f50c5907a9539d8e5bba7245f62c9f520aef333d13392a79a4f70aca719",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "mutagen",
+                        "packagetype": "bdist_wheel"
+                    }
+                }
+            ]
         },
         {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/98/67/d76cddb63710f88fb53f287b713f268579a85bfc81caacbb1b6048b60b85/yt_dlp-2026.1.31-py3-none-any.whl",
-            "sha256": "81f8e70c0d111b9572420cfea0ba9b4c2ae783fa1a4237fa767eeb777d4c5a58"
+            "name": "python3-yt-dlp",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"yt-dlp\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/cd/13/5093bcb954878e50f7217fd2ab94282b53934022e4e4a03265582da83bf5/yt_dlp-2026.3.17-py3-none-any.whl",
+                    "sha256": "32992db94303a8a5d211a183f2174834fe7f8c29d83ed2e7a324eae97a8f26d8",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "yt-dlp",
+                        "packagetype": "bdist_wheel"
+                    }
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
- Update the runtime version to 50
- Update Python dependencies
- Improve cleanup commands to reduce the Flatpak size
- Compile pyc files to improve performance

---

```
WARNING: [youtube] No supported JavaScript runtime could be found. 
Only deno is enabled by default; to use another runtime add  --js-runtimes 
RUNTIME[:PATH]  to your command/config. YouTube extraction without a JS runtime 
has been deprecated, and some formats may be missing. 
See  https://github.com/yt-dlp/yt-dlp/wiki/EJS  for details on installing one
```